### PR TITLE
Implement quick notes web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # codex_testes
-rep para testes do codex openai
+
+Rep para testes do Codex OpenAI
+
+## App de Notas Rápidas
+
+Abra o arquivo `index.html` em um navegador para adicionar e gerenciar suas notas com caixas de marcação.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Notas Rápidas</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    #task-input { width: 70%; padding: 10px; }
+    #add-btn { padding: 10px 20px; }
+    ul { list-style: none; padding: 0; }
+    li { margin: 5px 0; }
+    .done { text-decoration: line-through; color: #888; }
+  </style>
+</head>
+<body>
+  <h1>Notas Rápidas</h1>
+  <input id="task-input" type="text" placeholder="Digite sua ideia ou tarefa" />
+  <button id="add-btn">Adicionar</button>
+  <ul id="task-list"></ul>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,50 @@
+const taskInput = document.getElementById('task-input');
+const addBtn = document.getElementById('add-btn');
+const taskList = document.getElementById('task-list');
+
+let tasks = JSON.parse(localStorage.getItem('tasks')) || [];
+
+function saveTasks() {
+  localStorage.setItem('tasks', JSON.stringify(tasks));
+}
+
+function render() {
+  taskList.innerHTML = '';
+  tasks.forEach((task, index) => {
+    const li = document.createElement('li');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = task.done;
+    checkbox.addEventListener('change', () => {
+      task.done = checkbox.checked;
+      saveTasks();
+      render();
+    });
+    const span = document.createElement('span');
+    span.textContent = task.text;
+    if (task.done) span.classList.add('done');
+    li.appendChild(checkbox);
+    li.appendChild(span);
+    const removeBtn = document.createElement('button');
+    removeBtn.textContent = 'Remover';
+    removeBtn.addEventListener('click', () => {
+      tasks.splice(index, 1);
+      saveTasks();
+      render();
+    });
+    li.appendChild(removeBtn);
+    taskList.appendChild(li);
+  });
+}
+
+addBtn.addEventListener('click', () => {
+  const text = taskInput.value.trim();
+  if (text) {
+    tasks.push({ text, done: false });
+    taskInput.value = '';
+    saveTasks();
+    render();
+  }
+});
+
+render();


### PR DESCRIPTION
## Summary
- add simple HTML interface for notes with checkboxes
- persist tasks in localStorage via script.js
- update README with instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688678d0f5c083298cac4031ec0a728a